### PR TITLE
shoggoth maid bugfixes

### DIFF
--- a/Unlesh The Mods/mods/Battle-Maid-Redux-master/monsters.json
+++ b/Unlesh The Mods/mods/Battle-Maid-Redux-master/monsters.json
@@ -8,6 +8,7 @@
        "symbol":"M",
        "color":"white",
        "size":"SMALL",
+       "volume":"5 L",
        "diff":20,
        "aggression":10,
        "morale":100,
@@ -27,7 +28,7 @@
        "death_function":["MELT"],
        "special_attacks":[["PARROT", 40],["IMPALE", 25], ["STRETCH_ATTACK", 5]],
        "description":"A shoggoth mimicking the look of an attractive maid. Contrary to the neat appearance, her head has swirls of pink and iridescent colors swirling around. She has a deep seated love for her master.",
-       "flags":["SEES", "SMELLS", "HEARS", "SWIMS", "PLASTIC", "SLUDGEPROOF", "ACIDPROOF", "NOHEAD", "REVIVES", "NOGIB", "FLIES"],
+       "flags":["SEES", "SMELLS", "HEARS", "SWIMS", "PLASTIC", "SLUDGEPROOF", "ACIDPROOF", "NOHEAD", "REVIVES", "NOGIB"],
        "anger_triggers":["FRIEND_ATTACKED"]
    },
    {


### PR DESCRIPTION
Flight for pets is buggy and causes the shoggoth maid to get stuck on top of a roof when climbing a downspout. And the volume attribute is required in order to put them into a pet carrier, which their speech and small size suggests is possible.