### PR TITLE
Add itemgroup bees

### DIFF
--- a/1 Unlesh The Mods/mods/Mo' Insects/groups.json
+++ b/1 Unlesh The Mods/mods/Mo' Insects/groups.json
@@ -117,5 +117,19 @@
     "name": "GROUP_ANT",
     "default": "mon_ant_swarm",
     "monsters": [ { "monster": "mon_ant_swarm", "freq": 30, "cost_multiplier": 3 } ]
+  },
+  {
+    "id": "bees",
+    "type": "item_group",
+    "items": [
+      [ "mutant_meat", 75 ],
+      [ "sinew", 25 ],
+      [ "endochitin", 65 ],
+      [ "mutant_bug_hydrogen_sacs", 65 ],
+      [ "mutant_bug_lungs", 1 ],
+      [ "mutant_bug_organs", 5 ],
+      [ "bee_sting", 75 ],
+      [ "chitin_piece", 65 ]
+    ]
   }
 ]


### PR DESCRIPTION
I got this error:

 ```
DEBUG    : item group id bees is unknown (in item in Ƿ 1829)

 FUNCTION : virtual void Single_item_creator::check_consistency(const string&) const
 FILE     : src/item_group.cpp
 LINE     : 166

```

The group did not exist so I made a group based on a harvest group from the mainline called arachnid_bee. Maybe instead of death_drops it's better to use harvest like mon_bee does.

I only loaded the game and the warning is gone.
