### PR TITLE
42 small mod update

### DIFF
--- a/1 Unlesh The Mods/mods/42_small_mod/42sm_scenarios.json
+++ b/1 Unlesh The Mods/mods/42_small_mod/42sm_scenarios.json
@@ -7,22 +7,10 @@
     "flags": [ "INFECTED", "SUR_START", "CITY_START", "LONE_START" ],
     "points": -6,
     "allowed_locs": [
-      "mall_a_12",
-      "mall_a_30",
-      "apartments_con_tower_114",
-      "apartments_con_tower_014",
-      "apartments_con_tower_104",
-      "apartments_con_tower_004",
-      "hospital_1",
-      "hospital_2",
-      "hospital_3",
-      "hospital_4",
-      "hospital_5",
-      "hospital_6",
-      "hospital_7",
-      "hospital_8",
-      "hospital_9",
-      "megastore_1_0_0_s"
+      "sloc_mall_loading_area",
+      "sloc_mall_food_court",
+      "sloc_apartments_rooftop",
+      "sloc_hospital"
     ],
     "missions": [ "MISSION_INFECTED_START_FIND_ANTIBIOTICS" ],
     "start_name": "In Large Building"


### PR DESCRIPTION
I got these errors:

```
 DEBUG    : starting location mall_a_12 for scenario infected_large does not exist

 FUNCTION : void scenario::check_definition() const
 FILE     : src/scenario.cpp
 LINE     : 166


 DEBUG    : starting location mall_a_30 for scenario infected_large does not exist

 FUNCTION : void scenario::check_definition() const
 FILE     : src/scenario.cpp
 LINE     : 166


 DEBUG    : starting location apartments_con_tower_114 for scenario infected_large does not exist

 FUNCTION : void scenario::check_definition() const
 FILE     : src/scenario.cpp
 LINE     : 166


 DEBUG    : starting location apartments_con_tower_014 for scenario infected_large does not exist

 FUNCTION : void scenario::check_definition() const
 FILE     : src/scenario.cpp
 LINE     : 166


 DEBUG    : starting location apartments_con_tower_104 for scenario infected_large does not exist

 FUNCTION : void scenario::check_definition() const
 FILE     : src/scenario.cpp
 LINE     : 166


 DEBUG    : starting location apartments_con_tower_004 for scenario infected_large does not exist

 FUNCTION : void scenario::check_definition() const
 FILE     : src/scenario.cpp
 LINE     : 166


 DEBUG    : starting location hospital_1 for scenario infected_large does not exist

 FUNCTION : void scenario::check_definition() const
 FILE     : src/scenario.cpp
 LINE     : 166

```

It uses an old format for starting locations so I updated that. It's mostly the same but I could not find the megastore starting location so I removed it.