### PR TITLE
more city locations add house

### DIFF
--- a/1 Unlesh The Mods/mods/More_City_Locations/regional_overlay.json
+++ b/1 Unlesh The Mods/mods/More_City_Locations/regional_overlay.json
@@ -75,6 +75,17 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "house",
+    "name": "house",
+    "symbol": "35",
+    "color": "white",
+    "see_cost": 5,
+    "extras": "build",
+    "mondensity": 2,
+    "flags": [ "SIDEWALK" ]
+  },
+  {
+    "type": "overmap_terrain",
     "id": "construction_site",
     "name": "construction site",
     "symbol": "94",


### PR DESCRIPTION
I got this warning:
```

 DEBUG    : Mapgen house is not used by anything!

 FUNCTION : void mapgen_factory::check_consistency()
 FILE     : src/mapgen.cpp
 LINE     : 325


```

So I added the house to the overmap terrain. Now the warning is gone