### PR TITLE
[Experimental] Update start locations

### DIFF
--- a/data/Rebalance_mods/mods/Ex_Scen/ex_start_locations.json
+++ b/data/Rebalance_mods/mods/Ex_Scen/ex_start_locations.json
@@ -3,246 +3,246 @@
     "type": "start_location",
     "id": "shipwreck_river_1",
     "name": "Shipwreck",
-    "target": "shipwreck_river_1"
+    "terrain": [ "shipwreck_river_1" ]
   },
   {
     "type": "start_location",
     "id": "shipwreck_river_2",
     "name": "Shipwreck",
-    "target": "shipwreck_river_2"
+    "terrain": [ "shipwreck_river_2" ]
   },
   {
     "type": "start_location",
     "id": "shipwreck_river_3",
     "name": "Shipwreck",
-    "target": "shipwreck_river_3"
+    "terrain": [ "shipwreck_river_3" ]
   },
   {
     "type": "start_location",
     "id": "shipwreck_river_4",
     "name": "Shipwreck",
-    "target": "shipwreck_river_4"
+    "terrain": [ "shipwreck_river_4" ]
   },
   {
     "type": "start_location",
     "id": "barn_aban1",
     "name": "adandoned farm",
-    "target": "barn_aban1"
+    "terrain": [ "barn_aban1" ]
   },
   {
     "type": "start_location",
     "id": "bank",
     "name": "Bank",
-    "target": "bank"
+    "terrain": [ "bank" ]
   },
   {
     "type": "start_location",
     "id": "campground_1a",
     "name": "Campground",
-    "target": "campground_1a"
+    "terrain": [ "campground_1a" ]
   },
   {
     "type": "start_location",
     "id": "campground_1b",
     "name": "Campground",
-    "target": "campground_1b"
+    "terrain": [ "campground_1b" ]
   },
   {
     "type": "start_location",
     "id": "campground_2a",
     "name": "Campground",
-    "target": "campground_2a"
+    "terrain": [ "campground_2a" ]
   },
   {
     "type": "start_location",
     "id": "campground_2b",
     "name": "Campground",
-    "target": "campground_2b"
+    "terrain": [ "campground_2b" ]
   },
   {
     "type": "start_location",
     "id": "derelict_property",
     "name": "dereclict property",
-    "target": "derelict_property"
+    "terrain": [ "derelict_property" ]
   },
   {
     "type": "start_location",
     "id": "desolatebarn",
     "name": "desolate barn",
-    "target": "desolatebarn"
+    "terrain": [ "desolatebarn" ]
   },
   {
     "type": "start_location",
     "id": "bar",
     "name": "Bar",
-    "target": "bar"
+    "terrain": [ "bar" ]
   },
   {
     "type": "start_location",
     "id": "cathedral_b_NW",
     "name": "Cathedral",
-    "target": "cathedral_b_NW"
+    "terrain": [ "cathedral_b_NW" ]
   },
   {
     "type": "start_location",
     "id": "cathedral_b_NE",
     "name": "Cathedral",
-    "target": "cathedral_b_NE"
+    "terrain": [ "cathedral_b_NE" ]
   },
   {
     "type": "start_location",
     "id": "cathedral_b_SW",
     "name": "Cathedral",
-    "target": "cathedral_b_SW"
+    "terrain": [ "cathedral_b_SW" ]
   },
   {
     "type": "start_location",
     "id": "cathedral_b_SE",
     "name": "Cathedral",
-    "target": "cathedral_b_SE"
+    "terrain": [ "cathedral_b_SE" ]
   },
   {
     "type": "start_location",
     "id": "s_antique",
     "name": "Antique Shop",
-    "target": "s_antique"
+    "terrain": [ "s_antique" ]
   },
   {
     "type": "start_location",
     "id": "s_gun",
     "name": "Gun Shop",
-    "target": "s_gun"
+    "terrain": [ "s_gun" ]
   },
   {
     "type": "start_location",
     "id": "sewer",
     "name": "Sewers",
-    "target": "sewer"
+    "terrain": [ "sewer" ]
   },
   {
     "type": "start_location",
     "id": "public_works_NW",
     "name": "Public Works",
-    "target": "public_works_NW"
+    "terrain": [ "public_works_NW" ]
   },
   {
     "type": "start_location",
     "id": "public_works_NE",
     "name": "Public Works",
-    "target": "public_works_NE"
+    "terrain": [ "public_works_NE" ]
   },
   {
     "type": "start_location",
     "id": "public_works_SW",
     "name": "Public Works",
-    "target": "public_works_SW"
+    "terrain": [ "public_works_SW" ]
   },
   {
     "type": "start_location",
     "id": "public_works_SE",
     "name": "Public Works",
-    "target": "public_works_SE"
+    "terrain": [ "public_works_SE" ]
   },
   {
     "type": "start_location",
     "id": "subway",
     "name": "Subway",
-    "target": "subway"
+    "terrain": [ "subway" ]
   },
   {
     "type": "start_location",
     "id": "pawn",
     "name": "Pawn Shop",
-    "target": "pawn"
+    "terrain": [ "pawn" ]
   },
   {
     "type": "start_location",
     "id": "s_thrift",
     "name": "Thrift Store",
-    "target": "s_thrift"
+    "terrain": [ "s_thrift" ]
   },
   {
     "type": "start_location",
     "id": "hunter_shack",
     "name": "Swamp Shack",
-    "target": "hunter_shack"
+    "terrain": [ "hunter_shack" ]
   },
   {
     "type": "start_location",
     "id": "recyclecenter",
     "name": "Recycle Center",
-    "target": "recyclecenter"
+    "terrain": [ "recyclecenter" ]
   },
   {
     "type": "start_location",
     "id": "smallscrapyard",
     "name": "Small Scrapyard",
-    "target": "smallscrapyard"
+    "terrain": [ "smallscrapyard" ]
   },
   {
     "type": "start_location",
     "id": "trailhead",
     "name": "forest",
-    "target": "trailhead"
+    "terrain": [ "trailhead" ]
   },
   {
     "type": "start_location",
     "id": "junkyard",
     "name": "Junkyard",
-    "target": "junkyard"
+    "terrain": [ "junkyard" ]
   },
   {
     "type": "start_location",
     "id": "fema",
     "name": "Fema Camp",
-    "target": "fema"
+    "terrain": [ "fema" ]
   },
   {
     "type": "start_location",
     "id": "large_storage_units_1",
     "name": "Storage Units",
-    "target": "large_storage_units_1"
+    "terrain": [ "large_storage_units_1" ]
   },
   {
     "type": "start_location",
     "id": "large_storage_units_2",
     "name": "Sorage Units",
-    "target": "large_storage_units_2"
+    "terrain": [ "large_storage_units_2" ]
   },
   {
     "type": "start_location",
     "id": "large_storage_units_3",
     "name": "Storage Units",
-    "target": "large_storage_units_3"
+    "terrain": [ "large_storage_units_3" ]
   },
   {
     "type": "start_location",
     "id": "medium_storage_units_1",
     "name": "Storage Units",
-    "target": "medium_storage_units_1"
+    "terrain": [ "medium_storage_units_1" ]
   },
   {
     "type": "start_location",
     "id": "medium_storage_units_2",
     "name": "Storage Units",
-    "target": "medium_storage_units_2"
+    "terrain": [ "medium_storage_units_2" ]
   },
   {
     "type": "start_location",
     "id": "small_storage_units",
     "name": "Storage Units",
-    "target": "small_storage_units"
+    "terrain": [ "small_storage_units" ]
   },
   {
     "type": "start_location",
     "id": "cabin_strange",
     "name": "strange cabin",
-    "target": "cabin_strange"
+    "terrain": [ "cabin_strange" ]
   },
   {
     "type": "start_location",
     "id": "temple_finale",
     "name": "Strange Temple",
-    "target": "temple_finale"
+    "terrain": [ "temple_finale" ]
   }
 ]

--- a/data/Rebalance_mods/mods/Road_Warrior_Mod/start_locations.json
+++ b/data/Rebalance_mods/mods/Road_Warrior_Mod/start_locations.json
@@ -3,6 +3,6 @@
     "type": "start_location",
     "id": "gas_station",
     "name": "Gas Station",
-    "target": "gas_station"
+    "terrain": [ "gas_station" ]
   }
 ]

--- a/data/broken_mods/Standalone_Salvaged_Robots/robot_additions/start_locations.json
+++ b/data/broken_mods/Standalone_Salvaged_Robots/robot_additions/start_locations.json
@@ -3,6 +3,6 @@
     "type": "start_location",
     "id": "robot_dispatch",
     "name": "Robot Dispatch Center",
-    "target": "robot_dispatch_second"
+    "terrain": [ "robot_dispatch_second" ]
   }
 ]

--- a/data/unleash_The_Mods/mods/42_small_mod/42sm_start_locations.json
+++ b/data/unleash_The_Mods/mods/42_small_mod/42sm_start_locations.json
@@ -3,6 +3,6 @@
     "type": "start_location",
     "id": "megastore_1_0_0_s",
     "name": "Megastore Stockroom",
-    "target": "megastore_1_0_0"
+    "terrain": [ "megastore_1_0_0" ]
   }
 ]

--- a/data/unleash_The_Mods/mods/Fantasy_realm_scenarios/start_locations.json
+++ b/data/unleash_The_Mods/mods/Fantasy_realm_scenarios/start_locations.json
@@ -3,12 +3,12 @@
     "type": "start_location",
     "id": "mine",
     "name": "Mine Entrance",
-    "target": "mine_entrance"
+    "terrain": [ "mine_entrance" ]
   },
   {
     "type": "start_location",
     "id": "sewer",
     "name": "Sewer",
-    "target": "sewer"
+    "terrain": [ "sewer" ]
   }
 ]

--- a/data/unleash_The_Mods/mods/Freeform_start/free_start_locations.json
+++ b/data/unleash_The_Mods/mods/Freeform_start/free_start_locations.json
@@ -3,24 +3,24 @@
     "type": "start_location",
     "id": "pump_station_1",
     "name": "Pump Station",
-    "target": "pump_station_1"
+    "terrain": [ "pump_station_1" ]
   },
   {
     "type": "start_location",
     "id": "museum",
     "name": "Museum",
-    "target": "museum"
+    "terrain": [ "museum" ]
   },
   {
     "type": "start_location",
     "id": "cathedral",
     "name": "Cathedral",
-    "target": "cathedral_1_SW"
+    "terrain": [ "cathedral_1_SW" ]
   },
   {
     "type": "start_location",
     "id": "recyclecenter",
     "name": "Recycling Center",
-    "target": "recyclecenter"
+    "terrain": [ "recyclecenter" ]
   }
 ]

--- a/data/unleash_The_Mods/mods/Make_a_Lot_of_Items_Mod/MLI_start_location.json
+++ b/data/unleash_The_Mods/mods/Make_a_Lot_of_Items_Mod/MLI_start_location.json
@@ -3,12 +3,12 @@
     "type": "start_location",
     "id": "MLI_s_pasta_restaurant",
     "name": "Pasta restaurant",
-    "target": "MLI_s_pasta_restaurant"
+    "terrain": [ "MLI_s_pasta_restaurant" ]
   },
   {
     "type": "start_location",
     "id": "MLI_glass_workshop",
     "name": "Glass workshop",
-    "target": "MLI_glass_workshop"
+    "terrain": [ "MLI_glass_workshop" ]
   }
 ]

--- a/data/unleash_The_Mods/mods/Merchant/startlocation.json
+++ b/data/unleash_The_Mods/mods/Merchant/startlocation.json
@@ -3,6 +3,6 @@
     "type": "start_location",
     "id": "Market",
     "name": "Survivor village",
-    "target": "ZoneNE"
+    "terrain": [ "ZoneNE" ]
   }
 ]

--- a/data/unleash_The_Mods/mods/Psychiclysm/scenarios.json
+++ b/data/unleash_The_Mods/mods/Psychiclysm/scenarios.json
@@ -3,7 +3,7 @@
     "type": "start_location",
     "id": "cabin",
     "name": "Cabin",
-    "target": "cabin"
+    "terrain": [ "cabin" ]
   },
   {
     "type": "scenario",

--- a/data/unleash_The_Mods/mods/Randomized_Mall/start_locations.json
+++ b/data/unleash_The_Mods/mods/Randomized_Mall/start_locations.json
@@ -3,6 +3,6 @@
     "type": "start_location",
     "id": "mall_cross",
     "name": "Shopping Mall",
-    "target": "mall_cross"
+    "terrain": [ "mall_cross" ]
   }
 ]

--- a/data/unleash_The_Mods/mods/Toki_silly_classes/tsc_start_locations.json
+++ b/data/unleash_The_Mods/mods/Toki_silly_classes/tsc_start_locations.json
@@ -3,6 +3,6 @@
     "type": "start_location",
     "id": "tsc_m_basement_1",
     "name": "Mansion Basement",
-    "target": "mansion_+2d"
+    "terrain": [ "mansion_+2d" ]
   }
 ]

--- a/data/unleash_The_Mods/mods/miso_Touhou/scenarios.json
+++ b/data/unleash_The_Mods/mods/miso_Touhou/scenarios.json
@@ -171,7 +171,7 @@
     "type": "start_location",
     "id": "marisa_start01",
     "name": "Kirisame Magic Store",
-    "target": "marisanoie_2"
+    "terrain": [ "marisanoie_2" ]
   },
   {
     "type": "scenario",
@@ -196,7 +196,7 @@
     "type": "start_location",
     "id": "koumakan_modoki01",
     "name": "Scarlet Western Mansion",
-    "target": "koumakan00_4"
+    "terrain": [ "koumakan00_4" ]
   },
   {
     "type": "scenario",

--- a/data/unleash_The_Mods/mods/mycus/scenarios.json
+++ b/data/unleash_The_Mods/mods/mycus/scenarios.json
@@ -3,7 +3,7 @@
     "type": "start_location",
     "id": "mycus_start01",
     "name": "Fungus Institute",
-    "target": "mycus01"
+    "terrain": [ "mycus01" ]
   },
   {
     "type": "scenario",


### PR DESCRIPTION
<!---
name: pull request
about: Suggest an idea for a mod or the project
title: ''
labels: ''
milestones: 'Experimental Compilation 0.F Release'
Reviewers: 'TheGoatGod'

--->
<!---
**Tags**
[Experimental]
[E-3]
[Soundpacks]
[Tilesets]
[Fonts]
[Documentation]
--->


**Updates start locations.json**
changes `"target": "example` to `"terrain": [ "expample" ]`

1. Standalone_Salvaged_Robots 
2. Ex_Scen 
3. Road_Warrior_Mod 
4. 42_small_mod 
5. Fantasy_realm_scenarios 
6. Freeform_start 
7. Make_a_Lot_of_Items_Mod 
8. Merchant 
9. miso_Touhou 
10. mycus 
11. Psychiclysm 
12. Randomized_Mall 
13. Toki_silly_classes 